### PR TITLE
ci: docker scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+debug

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+# Docker Images for C-Rust
+
+In TOP level directory, run
+
+```
+docker build -t c-rust -f docker/c-rust.Dockerfile .
+```
+
+To run
+```
+docker run -it --rm c-rust
+```
+

--- a/docker/c-rust.Dockerfile
+++ b/docker/c-rust.Dockerfile
@@ -1,0 +1,41 @@
+FROM seahorn/seahorn-llvm14:nightly
+
+ENV SEAHORN=/home/usea/seahorn/bin/sea PATH="$PATH:/home/usea/seahorn/bin:/home/usea/bin:/home/usea/.cargo/bin"
+
+## install required pacakges
+USER root
+
+## Install latest cmake
+RUN apt -y remove --purge cmake
+RUN apt -y update
+RUN apt -y install wget python3-pip
+RUN python3 -m pip install --upgrade pip
+RUN pip3 install cmake --upgrade
+
+## Install rust
+USER usea
+WORKDIR /home/usea
+
+RUN bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none"
+RUN rustup install nightly-2022-08-01
+RUN rustup +nightly-2022-08-01 component add rust-src
+RUN cargo +nightly-2022-08-01 install --force cbindgen
+
+## import c-rust
+USER usea
+WORKDIR /home/usea
+#
+## assume we are run inside c-rust 
+RUN mkdir c-rust 
+COPY --chown=usea:usea . c-rust
+
+#
+WORKDIR /home/usea/c-rust
+#
+RUN rm -Rf build && mkdir build && cd build && cmake -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DSEAHORN_ROOT=/home/usea/seahorn ../ -GNinja && cmake --build .
+
+# run test
+RUN cd build && cmake --build . --target test
+#
+### set default user and wait for someone to login and start running verification tasks
+USER usea


### PR DESCRIPTION
Scripts to create the docker container.

The container is based on `seahorn-llvm14:nightly`. 
Rust and related dependencies are installed when the container is build.

C-Rust repo is compiled and tests are run during build.

The container can be used for CI as either nightly or on PRs. 
It can be made more efficient by caching rust install and build products.
These are rather large (multiple GBs).