### PR TITLE
fix: register all crates with workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,7 @@ cargo-features = ["profile-rustflags"]
 [workspace]
 
 members = [
-    "src/rust-jobs/add",
-    "src/rust-jobs/enum-as-param",
-    "src/rust-jobs/option",
-    "src/rust-jobs/option-and-then",
-    "src/rust-jobs/option-is-some-and",
-    "src/rust-jobs/option-or",
-    "src/rust-jobs/option-unwrap-or",
-    "src/rust-jobs/option-vec-map",
-    "src/rust-jobs/pointer",
-    "src/rust-jobs/string-parse",
-    "src/rust-jobs/vec",
-    "src/rust-jobs/vec-filter",
-    "src/rust-jobs/vec-sort-reverse"
+    "src/rust-jobs/*",
 ]
 
 [profile.dev]


### PR DESCRIPTION
All crates must be registered with the workspace for the build process to work correctly.