### PR TITLE
Locally defined sea_nd functions

### DIFF
--- a/src/rust-jobs/add/lib.rs
+++ b/src/rust-jobs/add/lib.rs
@@ -1,18 +1,22 @@
 use sea;
 
+// Define a sea_nd function
+sea::define_sea_nd!(sea_nd_arg, i32, 42);
 
+// Entry point for the proof
 #[no_mangle]
 pub extern "C" fn entrypt() {
-  let v = sea::nd_i32();
-  sea::assume(v >= 1);
-  let res = add(v, 7);
-  if v > 0 {
-    sea::sassert!(res > 7);
-  } else {
-    sea::sassert!(res <= 7);
-  }
+    let v = sea_nd_arg();
+    sea::assume(v >= 1);
+    let res = add(v, 7);
+    if v > 0 {
+        sea::sassert!(res > 7);
+    } else {
+        sea::sassert!(res <= 7);
+    }
 }
 
+// Function being verified
 #[no_mangle]
 fn add(x: i32, y: i32) -> i32 {
     x + y

--- a/src/sea-lib/seahorn.c
+++ b/src/sea-lib/seahorn.c
@@ -2,24 +2,19 @@
  * \brief Dummy implementation of SeaHorn verification builtins
  *
  * Dummy implementation is necessary to build Rust project with LTO.
- * The bodies of these functions are removed by SeaHorn before any 
- * optimizataion and verification takes place 
+ * The bodies of these functions are removed by SeaHorn before any
+ * optimizataion and verification takes place
  */
 #include "seahorn/seahorn.h"
-#include <stdint.h> 
+#include <stdbool.h>
+#include <stdint.h>
 
-void __VERIFIER_error (void) {
-    return;
-}
+void __VERIFIER_error(void) { return; }
 
-void __VERIFIER_assume (int i) {
-    return;
-}
+void __VERIFIER_assume(int i) { return; }
 
-void __SEA_assume(bool b) {
-    return;
-}
+void __SEA_assume(bool b) { return; }
 
-int32_t sea_nd_i32(void) {
-  return 0;
-}
+int32_t sea_nd_i32(void) { return 0; }
+
+bool sea_nd_bool(void) { return true; }

--- a/src/sea-lib/src/bindings.rs
+++ b/src/sea-lib/src/bindings.rs
@@ -54,3 +54,7 @@ extern "C" {
 extern "C" {
   pub fn sea_nd_i32() -> i32;
 }
+
+extern "C" {
+  pub fn sea_nd_bool() -> bool;
+}

--- a/src/sea-lib/src/seahorn.rs
+++ b/src/sea-lib/src/seahorn.rs
@@ -16,8 +16,9 @@ pub fn nd_i32() -> i32 {
 }
 
 #[no_mangle]
-#[inline(never)]
-pub fn nd2_i32() -> i32 { 42 }
+pub fn nd_bool() -> bool {
+  unsafe { bindings::sea_nd_bool() }
+}
 
 #[macro_export]
 macro_rules! sassert {
@@ -28,4 +29,36 @@ macro_rules! sassert {
     }}
 }
 
-
+/// Defines `sea_nd` function that returns nd value
+///
+/// The implementation generates a sea_nd function that
+/// attempts to confuse Rust optimizer from understanding what
+/// is the return of the function.
+///
+/// The first argument specifies the defined function name.
+/// It must start with the prefix `sea_nd`.
+///
+/// The second argument is the type for nondet values. The type
+/// is assumed to implement the Default trait
+///
+/// The third argument is a value to return in the implementation.
+/// It must be any value that is different from default value for the type.
+///
+/// # Example
+///
+/// define_seaa_nd!(sea_nd_foo, i32, 42);
+///
+#[macro_export]
+macro_rules! define_sea_nd {
+    ($name:ident,$typ:ty,$val:expr) => {
+        #[no_mangle]
+        #[inline(never)]
+        pub extern "C" fn $name() -> $typ {
+            if sea::nd_bool() {
+                <$typ>::default()
+            } else {
+                $val
+            }
+        }
+    };
+}


### PR DESCRIPTION
See `add` job for an example

New macro, `define_sea_nd!` that should be used to define non-deterministic functions locally in Rust. 
The goal is to not require creating such functions in C and call them externally from Rust.

The trick is to create a body of a `sea_nd` function that is complex enough for inter-procedural optimizer to give up.