### PR TITLE
Tinyvec nd tests + entrypoint fix

### DIFF
--- a/cmake/extract_tests.cmake.in
+++ b/cmake/extract_tests.cmake.in
@@ -26,7 +26,7 @@ function(sea_discover_tests_impl TARGET BC VERIFY_CMD)
   file(REMOVE ${ctest_file})  # delete the existing CTestFile
   foreach(TEST_NAME ${TEST_NAMES_LIST})
       file(APPEND ${ctest_file} "add_test(${TARGET}_${TEST_NAME}_unsat_test
-            \"${VERIFY_CMD}\" \"--expect=unsat\" \"--entry-point=${TEST_NAME}\" \"${BC}\" )\n")
+            \"${VERIFY_CMD}\" \"--expect=unsat\" \"--entry=${TEST_NAME}\" \"${BC}\" )\n")
       message(STATUS "Added test: ${TARGET}_${TEST_NAME}_unsat_test")
   endforeach()
 endfunction()

--- a/src/rust-jobs/tinyvec-arrayvec/lib.rs
+++ b/src/rust-jobs/tinyvec-arrayvec/lib.rs
@@ -8,16 +8,16 @@ use tinyvec::ArrayVec;
 pub extern "C" fn entrypt() {
     let v: u8 = sea::nd_u8();
     match v {
-        0  => test_append(),
-        1  => test_clear(),
-        2  => test_drain(),
-        3  => test_extend_from_slice(),
-        4  => test_fill(),
-        5  => test_from_array_empty(),
-        6  => test_from_array_len(),
+        0 => test_append(),
+        1 => test_clear(),
+        2 => test_drain(),
+        3 => test_extend_from_slice(),
+        4 => test_fill(),
+        5 => test_from_array_empty(),
+        6 => test_from_array_len(),
         // 7  => test_grab_spare_slice(),
-        8  => test_insert(),
-        9  => test_new(),
+        8 => test_insert(),
+        9 => test_new(),
         10 => test_pop(),
         11 => test_push(),
         12 => test_remove(),
@@ -33,7 +33,7 @@ pub extern "C" fn entrypt() {
         22 => test_try_from_array_len(),
         23 => test_try_insert(),
         24 => test_try_push(),
-        _  => ()
+        _ => (),
     }
 }
 
@@ -117,7 +117,7 @@ fn test_extend_from_slice() {
 
     v1.push(1);
     v1.push(2);
-    
+
     v2.push(3);
     v2.push(4);
 
@@ -215,7 +215,7 @@ fn test_insert() {
     let mut v: ArrayVec<[u32; 5]> = ArrayVec::new();
     v.push(1);
     v.push(3);
-    
+
     v.insert(1, 2);
 
     sea::sassert!(v.len() == 3);
@@ -239,7 +239,7 @@ fn test_insert() {
 #[no_mangle]
 fn test_new() {
     let v: ArrayVec<[u32; 0]> = ArrayVec::new();
-    
+
     sea::sassert!(v.len() == 0);
     sea::sassert!(v.capacity() == 0);
 
@@ -290,22 +290,57 @@ fn test_push() {
     sea::sassert!(false);
 }
 
+// TODO: Remove this version of test once panic has been migrated
+// #[no_mangle]
+// fn test_remove() {
+//     let mut v: ArrayVec<[u32; 2]> = ArrayVec::new();
+//     v.push(1);
+//     v.push(2);
+
+//     v.remove(1);
+
+//     sea::sassert!(v.len() == 1);
+//     sea::sassert!(v.capacity() == 2);
+
+//     // Index is out of range, so removal should panic.
+//     v.remove(1);
+
+//     // This assertion should not be reachable since the call to remove panics.
+//     sea::sassert!(false);
+// }
+
 #[no_mangle]
 fn test_remove() {
-    let mut v: ArrayVec<[u32; 2]> = ArrayVec::new();
-    v.push(1);
-    v.push(2);
+    let mut v: ArrayVec<[u32; 5]> = ArrayVec::new();
+    let len: usize = sea::nd_usize();
+    sea::assume(2 <= len && len <= 5);
 
-    v.remove(1);
+    for _i in 0..len {
+        v.push(sea::nd_u32());
+    }
 
-    sea::sassert!(v.len() == 1);
-    sea::sassert!(v.capacity() == 2);
+    let remove_point1: usize = sea::nd_usize();
+    sea::assume(remove_point1 < len);
 
-    // Index is out of range, so removal should panic.
-    v.remove(1);
+    v.remove(remove_point1);
+
+    sea::sassert!(v.len() == len - 1);
+    sea::sassert!(v.capacity() == 5);
+
+    let remove_point2: usize = sea::nd_usize();
+    sea::assume(remove_point2 < len);
+
+    v.remove(remove_point2);
+
+    sea::sassert!(v.len() == len - 2);
+    sea::sassert!(v.capacity() == 5);
+
+    // FIXME: Add back panic logic
+    // v is empty, so this should panic.
+    //v.swap_remove(0);
 
     // This assertion should not be reachable since the call to remove panics.
-    sea::sassert!(false);
+    // sea::sassert!(false);
 }
 
 #[no_mangle]
@@ -335,18 +370,18 @@ fn test_resize_with() {
     let mut v: ArrayVec<[u32; 8]> = ArrayVec::new();
 
     v.push(1);
-    v.resize_with(4, || { Default::default() });
+    v.resize_with(4, || Default::default());
 
     sea::sassert!(v.len() == 4);
     sea::sassert!(v[3] == Default::default());
 
-    v.resize_with(2, || { 1 });
+    v.resize_with(2, || 1);
 
     sea::sassert!(v.len() == 2);
     sea::sassert!(v[1] == Default::default());
 
     // This is larger than the capacity of the vector and should panic.
-    v.resize_with(16, || { Default::default() });
+    v.resize_with(16, || Default::default());
 
     // This assertion should not be reachable since the previous operation should panic.
     sea::sassert!(false);
@@ -380,7 +415,7 @@ fn test_retain() {
 fn test_set_len() {
     let val: usize = sea::nd_usize();
     sea::assume(val <= 10);
-    
+
     let mut v: ArrayVec<[u32; 10]> = ArrayVec::new();
 
     v.set_len(val);
@@ -428,7 +463,7 @@ fn test_set_len() {
 //         let _: ArrayVec<[u32; 4]> = v1.splice(1..2, 1..4).collect();
 //     }
 
-//     // This assertion should not be reachable since the previous assertion should panic. 
+//     // This assertion should not be reachable since the previous assertion should panic.
 //     sea::sassert!(false);
 // }
 
@@ -456,25 +491,36 @@ fn test_split_off() {
 
 #[no_mangle]
 fn test_swap_remove() {
-    let mut v: ArrayVec<[u32; 2]> = ArrayVec::new();
-    v.push(1);
-    v.push(2);
+    let mut v: ArrayVec<[u32; 5]> = ArrayVec::new();
+    let len: usize = sea::nd_usize();
+    sea::assume(2 <= len && len <= 5);
 
-    v.swap_remove(0);
+    for _i in 0..len {
+        v.push(sea::nd_u32());
+    }
 
-    sea::sassert!(v.len() == 1);
-    sea::sassert!(v.capacity() == 2);
+    let remove_point1: usize = sea::nd_usize();
+    sea::assume(remove_point1 < len);
 
-    v.swap_remove(0);
+    v.swap_remove(remove_point1);
 
-    sea::sassert!(v.len() == 0);
-    sea::sassert!(v.capacity() == 2);
+    sea::sassert!(v.len() == len - 1);
+    sea::sassert!(v.capacity() == 5);
 
+    let remove_point2: usize = sea::nd_usize();
+    sea::assume(remove_point2 < len);
+
+    v.swap_remove(remove_point2);
+
+    sea::sassert!(v.len() == len - 2);
+    sea::sassert!(v.capacity() == 5);
+
+    // FIXME: Add back panic logic
     // v is empty, so this should panic.
-    v.swap_remove(0);
+    //v.swap_remove(0);
 
     // This assertion should not be reachable since the call to remove panics.
-    sea::sassert!(false);
+    // sea::sassert!(false);
 }
 
 #[no_mangle]
@@ -554,7 +600,7 @@ fn test_try_insert() {
     let mut v: ArrayVec<[u32; 5]> = ArrayVec::new();
     v.push(1);
     v.push(3);
-    
+
     let result: Option<u32> = v.try_insert(1, 2);
 
     sea::sassert!(result.is_none());
@@ -579,15 +625,24 @@ fn test_try_insert() {
 
 #[no_mangle]
 fn test_try_push() {
-    let mut v: ArrayVec<[u32; 1]> = ArrayVec::new();
+    // NOTE: Create a vector of fixed size capacity
+    let mut v: ArrayVec<[u32; 5]> = ArrayVec::new();
 
-    let result: Option<u32> = v.try_push(1);
-    
-    sea::sassert!(result.is_none());
-    sea::sassert!(v.len() == 1);
-    
-    let result: Option<u32> = v.try_push(2);
+    // NOTE: Create a ND number of elements to push
+    let len: usize = sea::nd_usize();
+    sea::assume(len <= 5);
 
-    sea::sassert!(result.is_some());
-    sea::sassert!(v.len() == 1);
+    // NOTE: INVARIANT: We should always be able to push len elements since
+    // len is <= capacity
+    for i in 0..len {
+        let result: Option<u32> = v.try_push(sea::nd_u32());
+        sea::sassert!(result.is_none());
+        sea::sassert!(v.len() == i + 1); // len is 1-based, iterator is 0-based
+    }
+
+    // NOTE: INVARIANT: When len == capacity then another push fails
+    if v.len() == v.capacity() {
+        let result: Option<u32> = v.try_push(sea::nd_u32());
+        sea::sassert!(result.is_some());
+    }
 }

--- a/verify.py.in
+++ b/verify.py.in
@@ -138,9 +138,9 @@ def main(argv):
 
             if args.verbose:
                 print(' '.join(cmd))
-            # NOTE: Only return if exepectation is given AND
-            # we are in vacuity mode else exec
-            if args.expect is None:
+            # NOTE: Only exec if exepectation is not given AND
+            # we are NOT in vacuity mode
+            if args.expect is None and (not args.vac):
                 os.execv(cmd[0], cmd)
 
             import subprocess


### PR DESCRIPTION
See commit msgs for more context.
I've removed panic logic for now. It should be easy to add back -- add n elements and remove n + 1 elements in a loop.