### PR TITLE
Update ahash version

### DIFF
--- a/src/rust-jobs/borsh/Cargo.toml
+++ b/src/rust-jobs/borsh/Cargo.toml
@@ -17,6 +17,7 @@ path = "lib.rs"
 
 [dependencies]
 # compiler_builtins = { version = "0.1.99", features = ["no-asm"] }
+ahash = "=0.8.6"
 borsh = "0.10.3"
 
 


### PR DESCRIPTION
Ahash, which is a dependency of borsh, causes a build error when an earlier version is used. Specifying the ahash version in cargo file fixes the build error.

See https://github.com/solana-labs/solana/issues/34609 or https://github.com/rust-lang/rust/issues/86161#issuecomment-1885012778 for the error that was experienced.